### PR TITLE
Fix precedence by changing "return ... or ..." to "return (... or ...)"

### DIFF
--- a/lib/BPM/Engine/Role/WithPersistence.pm
+++ b/lib/BPM/Engine/Role/WithPersistence.pm
@@ -27,8 +27,8 @@ has 'connect_info' => (
 
 sub _build_schema {
     my $self = shift;
-    return BPM::Engine::Store->connect($self->connect_info)
-        or die("Could not connect to Store");
+    return (BPM::Engine::Store->connect($self->connect_info)
+        or die("Could not connect to Store"));
     }
 
 sub BUILD {}


### PR DESCRIPTION
Minor fix brought to light by a new-ish Perl warning: "or" has such a low precedence that "return X or Y" will always return X, even if X is false. I added parens. Changing "or" to "||" also would have worked.