### PR TITLE
Fix odd hash handles taskdata

### DIFF
--- a/lib/BPM/Engine/Role/HandlesTaskdata.pm
+++ b/lib/BPM/Engine/Role/HandlesTaskdata.pm
@@ -83,7 +83,7 @@ sub _performer {
 sub _message {
     my ($self, $msg, $process, $pi) = @_;
 
-    return unless $msg;
+    return {} unless $msg;
 
     my $res = {};
 
@@ -146,7 +146,7 @@ sub _message_params {
     }
 
 sub _service {
-    my $svc = shift or return;
+    my $svc = shift or return {};
 
     my $end = $svc->{Service}->{EndPoint}->{ExternalReference};
 

--- a/lib/BPM/Engine/Role/WithPersistence.pm
+++ b/lib/BPM/Engine/Role/WithPersistence.pm
@@ -27,8 +27,8 @@ has 'connect_info' => (
 
 sub _build_schema {
     my $self = shift;
-    return BPM::Engine::Store->connect($self->connect_info)
-        or die("Could not connect to Store");
+    return (BPM::Engine::Store->connect($self->connect_info)
+        or die("Could not connect to Store"));
     }
 
 sub BUILD {}


### PR DESCRIPTION
This fixes warnings when there are no messages going into a parallel merge task. Similar fix for "service" though I never saw it fail.